### PR TITLE
Fixfocus

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,8 +69,7 @@ function getActionFromLanguageId(languageId: string): string {
 
 export function activate(ctx: vscode.ExtensionContext): void {
   ctx.subscriptions.push(vscode.commands.registerCommand('extension.runner', () => {
-    var editor = vscode.window.activeTextEditor;
-    var document = editor.document;
+    var document = vscode.window.activeTextEditor.document;
     var fileName = document.fileName;
     var languageId = document.languageId;
 
@@ -87,7 +86,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
     var output = vscode.window.createOutputChannel('Runner: ' + action + ' ' + fileName);
     output.show(vscode.ViewColumn.Two);
     setTimeout(() => {
-      vscode.window.showTextDocument(editor.document)
+      vscode.window.showTextDocument(document)
     },50)
 	// TODO parse line and spawn command without shells. because it's not
 	// possible to get an error code of execute on windows.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,9 @@ export function activate(ctx: vscode.ExtensionContext): void {
       fileName = path.relative(cwd, fileName);  
     var output = vscode.window.createOutputChannel('Runner: ' + action + ' ' + fileName);
     output.show(vscode.ViewColumn.Two);
-    editor.show()
+    setTimeout(() => {
+      vscode.window.showTextDocument(editor.document)
+    },50)
 	// TODO parse line and spawn command without shells. because it's not
 	// possible to get an error code of execute on windows.
     var sh = win32 ? 'cmd' : '/bin/sh';


### PR DESCRIPTION
editor.show() is deprecated also there was an issue on focus back, the problem was cursor focus back to editor but output channel was still active, with using setTimeout this problem gone but I'm not sure if this is the right way to fix this
