### PR TITLE
Fix bug, change position

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,6 +84,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
     var cwd = vscode.workspace.rootPath;
     if(cwd != null)
       fileName = path.relative(cwd, fileName);  
+    fileName = win32 ? fileName : fileName.replace(/ /g, "\\ ");
     var output = vscode.window.createOutputChannel('Runner: ' + action + ' ' + fileName);
     output.show(vscode.ViewColumn.Two);
     setTimeout(() => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,7 @@ import path = require('path');
 const win32 = process.platform === 'win32';
 
 const defaultExtensionMap = {
-  coffee: "coffee",
-  r: "r -q --vanilla -f"
+  coffee: "coffee"
 }
 
 const defaultLanguageMap = {
@@ -22,6 +21,7 @@ const defaultLanguageMap = {
   php: "php",
   powershell: "powershell -noninteractive -noprofile -c -",
   python: "python",
+  r: "r -q --vanilla -f",
   ruby: "ruby",
   shell: "bash",
   typescript: "tsc"


### PR DESCRIPTION
- Fix can't execute when file path has ' ' chracter.
- move R language configuration from defaultExtensionMap to defaultLanguageMap

I found 'r' in small case can be recognized as language by vscode.
