### PR TITLE
FInally change r exec to `Rscript`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ const defaultLanguageMap = {
   php: "php",
   powershell: "powershell -noninteractive -noprofile -c -",
   python: "python",
-  r: "r -q --vanilla -f",
+  r: "Rscript",
   ruby: "ruby",
   shell: "bash",
   typescript: "tsc"


### PR DESCRIPTION
Tried to fix the problem that r script should saved before running by inspecting [atom script runner's resolution](https://github.com/rgbkrk/atom-script/pull/686/files) but failed :(

So there's no need for testing `r -...`command, decided to use simple `Rscript`to execute.

Uploading this version to vscode market would be great as bug fixed at #7 causes some inconvenience.
