### PR TITLE
Reverted from SIGINT to SIGTERM for process termination.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ node_modules
 out
 .vscode
 *.vsix
+
+# Compiled typescript
+src/extension.js

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,7 +76,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
       if (win32)
         cp.spawn('taskkill', ['/pid', currentProcess.pid.toString(), '/f', '/t']);
       else
-        currentProcess.kill('SIGINT');
+        currentProcess.kill();
     }
   }));
   ctx.subscriptions.push(vscode.commands.registerCommand('extension.runner.start', () => {


### PR DESCRIPTION
Sadly the emulation of CTRL+C by using SIGINT instead of SIGTERM does not really work with the current way how stuff is run on linux and osx. So we need to revert to SIGTERM.
